### PR TITLE
Macros

### DIFF
--- a/include/Arg.hpp
+++ b/include/Arg.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "utils.hpp"
 #include "Macros.hpp"
 
-#include <cerrno>
 #include <ostream>
 #include <iostream>
 #include <optional>

--- a/include/Arg.hpp
+++ b/include/Arg.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "utils.hpp"
+#include "Macros.hpp"
 
 #include <cerrno>
 #include <ostream>
@@ -42,78 +43,18 @@ class Arg {
     std::optional<std::string> value_;
 
     // ----| Getters & Setters |----
-    // name_
-    [[nodiscard]] inline const std::string& get__name() const {
-      return this->name_;
-    }
-    inline void set__name(const std::string& name) {
-      this->name_ = name;
-    }
-
-    // short_
-    [[nodiscard]] inline const std::string& get__short_name() const {
-      return this->short_name_;
-    }
-    inline void set__short_name(const std::string& short_name) {
-      this->short_name_ = short_name;
-    }
-
-    // long_
-    [[nodiscard]] inline const std::string& get__long_name() const {
-      return this->long_name_;
-    }
-    inline void set__long_name(const std::string& long_name) {
-      this->long_name_ = long_name;
-    }
-
-    // help_
-    [[nodiscard]] inline const std::string& get__help() const {
-      return this->help_;
-    }
-    inline void set__help(const std::string& help) {
-      this->help_ = help;
-    }
-
-    // required_
-    [[nodiscard]] inline bool get__is_required() const {
-      return this->is_required_;
-    }
-    inline void set__is_required(const bool& is_required) {
-      this->is_required_ = is_required;
-    }
-
-    // is_flag_
-    [[nodiscard]] inline bool get__is_flag() const {
-      return this->is_flag_;
-    }
-    inline void set__is_flag(const bool& takes_value) {
-      this->is_flag_ = takes_value;
-    }
-
-    // accepts_many_
-    [[nodiscard]] inline bool get__accepts_many() const {
-      return this->accepts_many_;
-    }
-    inline void set__accepts_many(const bool& accepts_many) {
-      this->accepts_many_ = accepts_many;
-    }
+    DEFINE_GETTER_SETTER(name, std::string)
+    DEFINE_GETTER_SETTER(short_name, std::string)
+    DEFINE_GETTER_SETTER(long_name, std::string)
+    DEFINE_GETTER_SETTER(help, std::string)
+    DEFINE_GETTER_SETTER(is_required, bool)
+    DEFINE_GETTER_SETTER(is_flag, bool)
+    DEFINE_GETTER_SETTER(accepts_many, bool)
+    DEFINE_GETTER_SETTER(env_name, std::string)
+    DEFINE_GETTER_SETTER(auto_env, bool)
+    DEFINE_GETTER_SETTER(default_value, std::string)
+    DEFINE_GETTER_SETTER(value, std::optional<std::string>)
     
-    // env_name_
-    [[nodiscard]] inline const std::string& get__env_name() const {
-      return this->env_name_;
-    }
-    inline void set__env_name(const std::string& env_name) {
-      this->env_name_ = env_name;
-    }
-
-    // auto_env_
-    [[nodiscard]] inline bool get__auto_env() const {
-      return this->auto_env_;
-    }
-    inline void set__auto_env(const bool& auto_env) {
-      this->auto_env_ = auto_env;
-    }
-
     // auto_env_name_
     // [[nodiscard]] inline const std::string get__auto_env_name() const {
     //   std::string env_name = PROGRAM_NAME() + '_' + this->get__name();
@@ -121,36 +62,13 @@ class Arg {
     //   return env_name;
     // }
 
-    // default_
-    [[nodiscard]] inline const std::string& get__default_value() const {
-      return this->default_value_;
-    }
-    inline void set__default_value(const std::string& default_value) {
-      this->default_value_ = default_value;
-    }
-
-    // value_
-    [[nodiscard]] inline const std::optional<std::string> get__value() const {
-      return this->value_;
-    }
-    inline void set__value(const std::string& value) {
-      this->value_ = value;
-    }
-
     // ----| Checkers |----
     // has_env_
-    [[nodiscard]] inline bool has_env() const {
-      return !this->env_name_.empty();
-    }
-
+    [[nodiscard]] inline bool has_env() const { return !this->env_name_.empty(); }
+    
     // has_default_
-    [[nodiscard]] inline bool has_default() const {
-      return !this->default_value_.empty();
-    }
+    [[nodiscard]] inline bool has_default() const { return !this->default_value_.empty(); }
 
     // has_value_
-    [[nodiscard]] inline bool has_value() const {
-      return this->value_.has_value();
-    }
-
+    [[nodiscard]] inline bool has_value() const { return this->value_.has_value(); }
 };

--- a/include/Arg.hpp
+++ b/include/Arg.hpp
@@ -38,7 +38,6 @@ class Arg {
     bool accepts_many_;
     std::string env_name_;
     bool auto_env_;
-    // std::string auto_env_name_;
     std::string default_value_;
     std::optional<std::string> value_;
 
@@ -55,13 +54,6 @@ class Arg {
     DEFINE_GETTER_SETTER(default_value, std::string)
     DEFINE_GETTER_SETTER(value, std::optional<std::string>)
     
-    // auto_env_name_
-    // [[nodiscard]] inline const std::string get__auto_env_name() const {
-    //   std::string env_name = PROGRAM_NAME() + '_' + this->get__name();
-    //   to_upper(env_name);
-    //   return env_name;
-    // }
-
     // ----| Checkers |----
     // has_env_
     [[nodiscard]] inline bool has_env() const { return !this->env_name_.empty(); }

--- a/include/Macros.hpp
+++ b/include/Macros.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#define DEFINE_PARSABLE_BASIC_TYPE(TYPE) \
+template<> \
+struct Parse<TYPE> { \
+    static std::optional<TYPE> parse(std::string_view s) { \
+        TYPE value; \
+        auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value); \
+        if (ec == std::errc()) return value; \
+        return std::nullopt; \
+    } \
+};
+
+#define DEFINE_PARSABLE_FLOAT_TYPE(TYPE, CONVERT_FN) \
+template<> \
+struct Parse<TYPE> { \
+    static std::optional<TYPE> parse(std::string_view s) { \
+        char* end = nullptr; \
+        TYPE value = CONVERT_FN(s.data(), &end); \
+        if (end == s.data() + s.size()) return value; \
+        return std::nullopt; \
+    } \
+};
+
+#define DEFINE_GETTER_SETTER(NAME, TYPE)                                         \
+  [[nodiscard]] inline const TYPE& get__##NAME() const { return this->NAME##_; } \
+  inline void set__##NAME(const TYPE& NAME) { this->NAME##_ = NAME; }

--- a/include/Parsables.hpp
+++ b/include/Parsables.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Macros.hpp"
+
+#include <charconv>
+#include <cstdint>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+
+template<typename T>
+struct Parse {
+    static_assert(sizeof(T) == 0, "No Parse<T> specialization defined for this type");
+};
+
+template<typename T>
+concept Parseable = requires(std::string_view s) {
+    { Parse<T>::parse(s) } -> std::convertible_to<std::optional<T>>;
+};
+
+// Integer types
+DEFINE_PARSABLE_BASIC_TYPE(long long)
+DEFINE_PARSABLE_BASIC_TYPE(unsigned long long)
+DEFINE_PARSABLE_BASIC_TYPE(int8_t)
+DEFINE_PARSABLE_BASIC_TYPE(uint8_t)
+DEFINE_PARSABLE_BASIC_TYPE(int16_t)
+DEFINE_PARSABLE_BASIC_TYPE(uint16_t)
+DEFINE_PARSABLE_BASIC_TYPE(int32_t)
+DEFINE_PARSABLE_BASIC_TYPE(uint32_t)
+DEFINE_PARSABLE_BASIC_TYPE(int64_t)
+DEFINE_PARSABLE_BASIC_TYPE(uint64_t)
+
+// Floating-point types
+DEFINE_PARSABLE_FLOAT_TYPE(float, std::strtof)
+DEFINE_PARSABLE_FLOAT_TYPE(double, std::strtod)
+DEFINE_PARSABLE_FLOAT_TYPE(long double, std::strtold)
+
+template<>
+struct Parse<std::string> {
+    static std::optional<std::string> parse(std::string_view s) {
+        return std::string(s.data());
+    }
+};
+
+template<>
+struct Parse<bool> {
+    static std::optional<bool> parse(std::string_view s) {
+      auto as_int = Parse<int>::parse(s).value();
+      return as_int;
+    }
+};

--- a/include/Parsables.hpp
+++ b/include/Parsables.hpp
@@ -20,8 +20,6 @@ concept Parseable = requires(std::string_view s) {
 };
 
 // Integer types
-DEFINE_PARSABLE_BASIC_TYPE(long long)
-DEFINE_PARSABLE_BASIC_TYPE(unsigned long long)
 DEFINE_PARSABLE_BASIC_TYPE(int8_t)
 DEFINE_PARSABLE_BASIC_TYPE(uint8_t)
 DEFINE_PARSABLE_BASIC_TYPE(int16_t)

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -5,11 +5,7 @@
 #include "Parsables.hpp"
 
 #include <optional>
-#include <string_view>
-#include <type_traits>
-#include <system_error>
 #include <cstdlib>
-#include <charconv>
 #include <iostream>
 #include <optional>
 #include <string>

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -2,6 +2,7 @@
 
 #include "Arg.hpp"
 #include "utils.hpp"
+#include "Parsables.hpp"
 
 #include <optional>
 #include <string_view>
@@ -13,59 +14,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-template<typename T>
-struct Parse {
-    static std::optional<T> parse(std::string_view s) {
-        if constexpr (std::is_integral_v<T>) {
-            T value;
-            auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
-            if (ec == std::errc()) return value;
-            return std::nullopt;
-        }
-        else if constexpr (std::is_same_v<T, float>) {
-            char* end = nullptr;
-            float value = std::strtof(s.data(), &end);
-            if (end == s.data() + s.size()) return value;
-            return std::nullopt;
-        }
-        else if constexpr (std::is_same_v<T, double>) {
-            char* end = nullptr;
-            double value = std::strtod(s.data(), &end);
-            if (end == s.data() + s.size()) return value;
-            return std::nullopt;
-        }
-        else if constexpr (std::is_same_v<T, long double>) {
-            char* end = nullptr;
-            long double value = std::strtold(s.data(), &end);
-            if (end == s.data() + s.size()) return value;
-            return std::nullopt;
-        }
-        else {
-            static_assert(sizeof(T) == 0, "No Parse<T> specialization defined for this type");
-        }
-    }
-};
-
-template<>
-struct Parse<std::string> {
-    static std::optional<std::string> parse(std::string_view s) {
-        return std::string(s);
-    }
-};
-
-template<>
-struct Parse<bool> {
-    static std::optional<bool> parse(std::string_view s) {
-      auto as_int = Parse<int>::parse(s).value();
-      return as_int;
-    }
-};
-
-template<typename T>
-concept Parseable = requires(std::string_view s) {
-    { Parse<T>::parse(s) } -> std::convertible_to<std::optional<T>>;
-};
 
 class ClapParser {
   public:

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -25,14 +25,6 @@ class ClapParser {
     requires Parseable<T>
     inline std::optional<T> get_one_as(const std::string& name) {
         Arg* arg = ok_or(ClapParser::find_arg(*this, "--" + name), []{ return std::nullopt; });
-
-        // if (auto arg_value = arg->get__value(); arg_value) {
-        //     T value;
-        //     std::istringstream(*arg_value) >> value;
-        //     return value;
-        // }
-        // return std::nullopt;
-
         return Parse<T>::parse(arg->get__value().value());
     }
 
@@ -54,5 +46,4 @@ class ClapParser {
     void check_env();
     void parse_positional_args(const std::vector<std::string>& args);
     static void parse_value_for_non_flag(Arg* arg, size_t& cli_index, const std::vector<std::string>& args);
-    void handle_missing_positional(const Arg& arg);
 };

--- a/src/Arg.cpp
+++ b/src/Arg.cpp
@@ -1,6 +1,6 @@
 #include "Arg.hpp"
+#include "utils.hpp"
 
-#include <cstdlib>
 #include <optional>
 #include <pthread.h>
 #include <string>

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -107,10 +107,6 @@ bool ClapParser::is_short_option(const std::string& token) {
 
 void ClapParser::print_help() const {
     std::cout << "Usage: " << this->program_name_ << " [OPTIONS]";
-    auto positionals = get_positional_args();
-    for (const auto& pos : positionals) {
-        std::cout << " [" << pos.get__name() << "]";
-    }
     std::cout << "\n\nOptions:\n";
 
     for (const auto& arg : args_) {
@@ -135,16 +131,6 @@ void ClapParser::print_help() const {
     std::cout << "--help";
     std::cout << "\t" << "Prints this help message";
     std::cout << "\n";
-
-    if (!positionals.empty()) {
-        std::cout << "\nPositional arguments:\n";
-        for (const auto& pos : positionals) {
-            std::cout << "  " << pos.get__name() << "\t" << pos.get__help();
-            if (pos.has_default())
-                std::cout << " (default: " << pos.get__default_value() << ")";
-            std::cout << "\n";
-        }
-    }
 }
 
 // Helper methods
@@ -157,16 +143,6 @@ std::optional<Arg*> ClapParser::find_arg(ClapParser& parser, const std::string& 
         return std::nullopt;
     }
     return &(*it);
-}
-
-std::vector<Arg> ClapParser::get_positional_args() const {
-    std::vector<Arg> positional;
-    for (const auto& arg : args_) {
-        if (arg.get__short_name().empty() && arg.get__long_name().empty()) {
-            positional.push_back(arg);
-        }
-    }
-    return positional;
 }
 
 void ClapParser::apply_defaults() {


### PR DESCRIPTION
**Features:**
- Introduced macros for code generation in the Parser module.

**Refactoring & Cleanup:**
- Changed to macro-based getters and setters for the Arg module.
- Moved 'Parsable' and its implementations to a new header file, Parsables.hpp.
- Removed all unused imports across the codebase.
- Cleaned up old and unused code in the Parser and Arg modules.
- Eliminated redefinition of int64_t and uint64_t in Parsables.